### PR TITLE
feat: Enhance document type support for ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Built with:
 
 ---
 
+## 📋 Supported Document Types
+
+This service supports a variety of document types for ingestion, including:
+- Standard formats like PDF, DOCX, PPTX, TXT, CSV, Markdown (handled by LlamaIndex's default readers).
+- Enhanced support for JSON documents (`.json`) using `JSONReader`.
+- Custom parsing for XML documents (`.xml`) to extract all text content.
+
+The system leverages LlamaIndex's `file_extractor` mechanism, allowing for future extensions to support additional custom document parsers.
+
+---
+
 ## ⚙️ Local Development Setup
 
 1. **Clone the repo**
@@ -210,7 +221,7 @@ Test ingestion with curl:
 curl -X POST http://localhost:8080/ingest-file \
   -H "Content-Type: application/json" \
   -d '{
-    "file_path": "test/file.pdf",
+    "file_path": "test/file.pdf", # Other supported types include .json, .xml, .docx, .txt, etc.
     "vector_table_name": "your-kb-id"
   }'
 ```
@@ -221,7 +232,7 @@ Or test ingestion from Python:
 import requests
 
 res = requests.post("http://localhost:8080/ingest-file", json={
-    "file_path": "test/file.pdf",
+    "file_path": "test/file.pdf", # Other supported types include .json, .xml, .docx, .txt, etc.
     "vector_table_name": "your-kb-id"
 })
 print(res.json())

--- a/custom_readers.py
+++ b/custom_readers.py
@@ -1,0 +1,35 @@
+import xml.etree.ElementTree as ET
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+from pathlib import Path
+
+class CustomXmlReader(BaseReader):
+    """Custom XML parser that extracts all text content from an XML file."""
+
+    def load_data(self, file: Path, extra_info=None):
+        """Parse XML file and extract text content.
+
+        Args:
+            file (Path): The path to the XML file.
+            extra_info (Optional[dict]): Extra info to be associated with the Document.
+
+        Returns:
+            List[Document]: A list containing a single Document with extracted text.
+        """
+        text_content = []
+        try:
+            tree = ET.parse(file)
+            root = tree.getroot()
+            for element in root.iter():
+                if element.text:
+                    text_content.append(element.text.strip())
+        except ET.ParseError as e:
+            print(f"Error parsing XML file {file}: {e}")
+            # Return an empty document or raise error, depending on desired handling
+            return [Document(text="", extra_info=extra_info or {})]
+        except Exception as e:
+            print(f"An unexpected error occurred while processing XML file {file}: {e}")
+            return [Document(text="", extra_info=extra_info or {})]
+
+        full_text = " ".join(filter(None, text_content))
+        return [Document(text=full_text, extra_info=extra_info or {})]

--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ import logging
 from typing import Optional
 from tqdm import tqdm
 from llama_index.readers.gcs import GCSReader
+from llama_index.readers.json import JSONReader # Added
+from custom_readers import CustomXmlReader # Added
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.vector_stores.postgres import PGVectorStore
 from llama_index.core import VectorStoreIndex, StorageContext, Document
@@ -105,9 +107,15 @@ def index_documents(docs, source: str, vector_table_name: str):
 async def ingest_gcs_docs(payload: IngestRequest):
     try:
         logger.info(f"🔎 Starting GCS ingestion for prefix: {payload.gcs_prefix}")
+        # Configure custom file extractors to ensure JSON and XML are parsed correctly
+        file_extractor = {
+            ".json": JSONReader(),
+            ".xml": CustomXmlReader()
+        }
         reader_kwargs = {
             "bucket": GCS_BUCKET,
-            "prefix": payload.gcs_prefix
+            "prefix": payload.gcs_prefix,
+            "file_extractor": file_extractor
         }
 
         if CREDENTIALS_PATH and os.path.exists(CREDENTIALS_PATH):
@@ -143,9 +151,15 @@ async def ingest_gcs_docs(payload: IngestRequest):
 async def ingest_single_file(payload: FileIngestRequest):
     try:
         logger.info(f"📄 Ingesting single file: {payload.file_path}")
+        # Configure custom file extractors to ensure JSON and XML are parsed correctly
+        file_extractor = {
+            ".json": JSONReader(),
+            ".xml": CustomXmlReader()
+        }
         reader_kwargs = {
             "bucket": GCS_BUCKET,
-            "key": payload.file_path
+            "key": payload.file_path,
+            "file_extractor": file_extractor
         }
 
         if CREDENTIALS_PATH and os.path.exists(CREDENTIALS_PATH):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ google-cloud-secret-manager
 google-cloud-storage
 llama-index
 llama-index-readers-gcs
+llama-index-readers-json
 llama-index-embeddings-openai
 llama-index-vector-stores-postgres
 tqdm

--- a/tests/test_data/sample.json
+++ b/tests/test_data/sample.json
@@ -1,0 +1,1 @@
+{"key": "value", "text": "Hello JSON content"}

--- a/tests/test_data/sample.xml
+++ b/tests/test_data/sample.xml
@@ -1,0 +1,1 @@
+<root><item>Hello</item><item>XML content</item></root>

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,0 +1,89 @@
+import os
+import tempfile
+import shutil
+from pathlib import Path
+import unittest
+
+from llama_index.core.schema import Document
+from llama_index.core.readers import SimpleDirectoryReader # Corrected import
+from llama_index.readers.json import JSONReader
+
+# Assuming custom_readers.py is in the parent directory or PYTHONPATH is set up
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from custom_readers import CustomXmlReader
+
+
+class TestCustomReaders(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory to store test files
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.xml_file_path = self.test_dir / "sample.xml"
+        with open(self.xml_file_path, "w", encoding="utf-8") as f: # Added encoding
+            f.write("<root><item>Hello</item><item>XML content</item><empty></empty><tag with_attr='true'>More text</tag></root>")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_custom_xml_reader(self):
+        reader = CustomXmlReader()
+        documents = reader.load_data(file=self.xml_file_path)
+        self.assertEqual(len(documents), 1)
+        self.assertIsInstance(documents[0], Document)
+        # Based on the CustomXmlReader logic: iterate all elements, get text, strip, join with space
+        self.assertEqual(documents[0].text, "Hello XML content More text")
+
+
+class TestSimpleDirectoryReaderExtensions(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.json_file_path = self.test_dir / "sample.json"
+        self.xml_file_path = self.test_dir / "sample_for_sdr.xml"
+
+        with open(self.json_file_path, "w", encoding="utf-8") as f: # Added encoding
+            f.write('{"key": "value", "text_content": "JSON data here"}')
+        with open(self.xml_file_path, "w", encoding="utf-8") as f: # Added encoding
+            f.write("<doc><para>XML for SDR</para><para>Another para</para></doc>")
+
+        self.file_extractor = {
+            ".json": JSONReader(),
+            ".xml": CustomXmlReader()
+        }
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_sdr_with_custom_extractors(self):
+        reader = SimpleDirectoryReader(
+            input_dir=self.test_dir,
+            file_extractor=self.file_extractor,
+            # Explicitly tell SimpleDirectoryReader to look for all files,
+            # otherwise it might only pick up its default known extensions + .json, .xml
+            # However, the file_extractor should make it pick them up.
+            # Let's test default behavior first. If it fails, we can add required_exts.
+        )
+        documents = reader.load_data()
+
+        self.assertEqual(len(documents), 2, f"Expected 2 documents, got {len(documents)}. Files in dir: {os.listdir(self.test_dir)}")
+
+        json_doc_found = False
+        xml_doc_found = False
+
+        for doc in documents:
+            if doc.metadata["file_name"] == "sample.json":
+                json_doc_found = True
+                # JSONReader by default loads the raw content of the JSON file.
+                # For '{"key": "value", "text_content": "JSON data here"}'
+                # The text will be something like '"key": "value",\n"text_content": "JSON data here"'
+                self.assertIn('"key": "value"', doc.text)
+                self.assertIn('"text_content": "JSON data here"', doc.text)
+
+            elif doc.metadata["file_name"] == "sample_for_sdr.xml":
+                xml_doc_found = True
+                self.assertEqual(doc.text, "XML for SDR Another para")
+
+        self.assertTrue(json_doc_found, "JSON document not found or processed")
+        self.assertTrue(xml_doc_found, "XML document not found or processed")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces improved handling for JSON and XML document types and updates the project to reflect these capabilities.

Key changes:
- Integrated `JSONReader` from `llama-index-readers-json` for parsing JSON files.
- Implemented a `CustomXmlReader` to extract text content from XML files.
- Configured `GCSReader` to use these specific readers via the `file_extractor` parameter, ensuring more robust parsing for these types.
- Added `llama-index-readers-json` to `requirements.txt`.
- Introduced unit tests for `CustomXmlReader` and for `SimpleDirectoryReader` with the new file extractors, verifying their functionality.
- Updated `README.md` to include details about the newly supported document types (JSON, XML) and to clarify overall file type handling.
- Added explanatory comments in `main.py` for the `file_extractor` configuration.

The changes maintain the existing architecture of a separate ingestion service, which remains appropriate for the task.